### PR TITLE
theme: Fix RSS link

### DIFF
--- a/themes/ace-documentation/layouts/partials/header.html
+++ b/themes/ace-documentation/layouts/partials/header.html
@@ -31,7 +31,7 @@
     </div>
     {{ with .OutputFormats.Get "rss" -}}
         <div class="feed-icons">
-            <a href=".Permalink"><img src="/img/feed-icon.svg" alt="RSS feed" /></a>
+            <a href="{{.Permalink}}"><img src="/img/feed-icon.svg" alt="RSS feed" /></a>
         </div>
     {{ end -}}
 </nav>


### PR DESCRIPTION
Linked to the literal `.Permalink` instead of the RSS feed