### PR TITLE
Publish existing account docs

### DIFF
--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -16,7 +16,7 @@ instance](https://snikket.org/service/) or if you already know someone who has
 one, ask them for an invitation.
 
 ## Existing accounts
-    
+
 If you already have an account, learn how to [sign in to your account](sign-in/).
 Once you are set up, you can learn more about adding, removing and backing up
 your account data in [Managing Your Accounts](managing-accounts/).

--- a/content/getting-started/sign-in.md
+++ b/content/getting-started/sign-in.md
@@ -1,6 +1,5 @@
 ---
 title: Connecting to an existing account
-draft: true
 ---
 
 ## Adding a new device to your account
@@ -23,7 +22,7 @@ If you want to move to a new device (and stop using Snikket on the old device)
 you can transfer your account and conversation history.
 
 {{< panel style="warning" >}}
-**Using the same account to more than one device?**
+**Using the same account for more than one device?**
 Do not use this method to access the same account on multiple devices,
 only use it if you will no longer be using Snikket on the original device.
 {{< /panel >}}
@@ -32,3 +31,5 @@ First of all, on the old device, [create a backup](managing-accounts/#creating-a
 of your account. Transfer the backup file to your new device.
 
 To import the file on your new device, open the app. On Android, navigate to
+"Manage Accounts" and choose "Restore backup" from the dropdown menu. Select
+your backup file and follow the instructions.


### PR DESCRIPTION
Wording, spacing and some additional instructions to get the backup restored.

I guess using images + separating instructions based on clients will be required later but for now, this seems fine?